### PR TITLE
Zihe/implement gating token

### DIFF
--- a/contract/Move.lock
+++ b/contract/Move.lock
@@ -21,6 +21,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.26.2"
+compiler-version = "1.31.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/contract/sources/gating.move
+++ b/contract/sources/gating.move
@@ -1,0 +1,68 @@
+module contract::walrus_hackathon;
+
+use sui::vec_set::{Self,VecSet};
+use sui::random::{Self,Random,RandomGenerator};
+
+public struct ShortListed has key {
+    id: UID,
+    // If a team submitted 2 projects, they will need to provide different addresses
+    // to be considered as 2 different teams
+    projects: VecSet<address>,
+}
+
+public struct TeamPolarBear has key {
+    id: UID
+}
+
+public struct TeamOrca has key {
+    id: UID
+}
+
+public struct OrganizerCap has key, store {
+    id: UID
+}
+
+fun init(ctx: &mut TxContext) {
+    let cap = OrganizerCap {
+        id: object::new(ctx)
+    };
+    transfer::public_transfer(cap, ctx.sender());
+    let short_listed = ShortListed {
+        id: object::new(ctx),
+        projects: vec_set::empty(),
+    };
+    transfer::share_object(short_listed);
+}
+
+public fun add_projects(_: &OrganizerCap, sl: &mut ShortListed, new_projects: vector<address>) {
+    new_projects.do!(|project| {
+        sl.projects.insert(project);
+    });
+}
+
+entry fun select_teams(random: &Random, _: &OrganizerCap, sl: &ShortListed, ctx: &mut TxContext) {
+    let mut rng = random.new_generator(ctx);
+    let mut projects = sl.projects.into_keys();
+    rng.shuffle(&mut projects);
+    // divide the projects into 2 teams
+    // if the number of projects is odd, the first team will have 1 more project
+    let n = projects.length();
+    let n1 = n / 2;
+    let mut i = 0;
+    while (i < projects.length()) {
+        if (i >= n1) {
+            let o = TeamOrca {
+                id: object::new(ctx)
+            };
+            transfer::transfer(o, *projects.borrow(i));
+        } else {
+            let p = TeamPolarBear {
+                id: object::new(ctx)
+            };
+            transfer::transfer(p, *projects.borrow(i));
+        };
+
+        i = i + 1;
+    }
+}
+

--- a/contract/sources/voting.move
+++ b/contract/sources/voting.move
@@ -1,132 +1,162 @@
-module contract::voting {
-    use sui::table::{Self, Table};
-    use sui::vec_set::{Self, VecSet};
-    
-    use std::string::String;
-    use std::type_name::{Self, TypeName};
+module contract::voting;
 
-    // errors
-    const ETypeNotWhitelisted: u64 = 0;
-    const ETypeNotEnabled: u64 = 1;
-    const EVoteAlreadyCast: u64 = 2;
-    const EInvalidSubmission: u64 = 3;
+use sui::table::{Self, Table};
+
+use std::string::String;
+use std::type_name::{Self, TypeName};
+
+// errors
+const ETypeNotWhitelisted: u64 = 0;
+const ETypeNotEnabled: u64 = 1;
+const EVoteAlreadyCast: u64 = 2;
+const EInvalidSubmission: u64 = 3;
+const EVoteNotCast: u64 = 4;
 
 
-
-    // This is a registry with all the tokens that are allowed to vote and the votes themselves
-    // Assumes that there is only one hackathon at one time that community can vote for.
-    // Allows an address to vote multiple times if they own many allowed types, but only once per type
-    public struct EventVotes has key {
-        id: UID,
-        name: String,
-        whitelist: Table<TypeName, bool>,
-        votes: Table<String, u32>,
-        voter_used_id: Table<ID, bool>
+// This is a registry with all the tokens that are allowed to vote and the votes themselves
+// Assumes that there is only one hackathon at one time that community can vote for.
+// Allows an address to vote multiple times if they own many allowed types, but only once per type
+public struct EventVotes has key {
+    id: UID,
+    name: String,
+    whitelist: Table<TypeName, bool>,
+    votes: Table<String, u32>,
+    voter_used_id: Table<ID, bool>
 }
 
-    public struct OrganizerCap has key, store {
-        id: UID,
+public struct Ballot has key {
+    id: UID,
+    votes: vector<String>
+}
 
-    }
+
+public struct OrganizerCap has key, store {
+    id: UID,
+}
 
 
-    fun init(ctx: &mut TxContext) {
-        let cap = OrganizerCap {
-            id: object::new(ctx)
-        };
-        transfer::public_transfer(cap, ctx.sender());
-    }
+fun init(ctx: &mut TxContext) {
+    let cap = OrganizerCap {
+        id: object::new(ctx)
+    };
+    transfer::public_transfer(cap, ctx.sender());
+}
 
-    // Gated functions
+// Gated functions
 
-    // new_event returns the EventVotes object but this should be shared in the same PTB, the idea is that allowed types can be added before being shared
-    public fun new_event(_: &OrganizerCap, name: String, mut submissions: vector<String>, ctx: &mut TxContext): EventVotes {
-        let mut votes = table::new<String, u32>(ctx);
-        while(!submissions.is_empty()) {
-            let sumbmission = submissions.pop_back<String>();
-            votes.add<String, u32>(sumbmission, 0u32);
-        };
-        let event = EventVotes {
-            id: object::new(ctx),
-            name,
-            whitelist: table::new<TypeName, bool>(ctx),
-            votes,
-            voter_used_id: table::new<ID, bool>(ctx)
-        };
+// new_event returns the EventVotes object but this should be shared in the same PTB, the idea is that allowed types can be added before being shared
+public fun new_event(_: &OrganizerCap, name: String, mut submissions: vector<String>, ctx: &mut TxContext): EventVotes {
+    let mut votes = table::new<String, u32>(ctx);
+    while(!submissions.is_empty()) {
+        let sumbmission = submissions.pop_back<String>();
+        votes.add<String, u32>(sumbmission, 0u32);
+    };
+    let event = EventVotes {
+        id: object::new(ctx),
+        name,
+        whitelist: table::new<TypeName, bool>(ctx),
+        votes,
+        voter_used_id: table::new<ID, bool>(ctx)
+    };
 
-        event
-    }
+    event
+}
 
-    public fun add_eligble_type<T>(self: &mut EventVotes, _: &OrganizerCap) {
-        let tn = type_name::get<T>();
-        self.whitelist.add<TypeName, bool>(tn, true);
-    }
+public fun add_eligible_type<T>(self: &mut EventVotes, _: &OrganizerCap) {
+    let tn = type_name::get<T>();
+    self.whitelist.add<TypeName, bool>(tn, true);
+}
 
-    public fun disable_type<T>(self: &mut EventVotes, _: &OrganizerCap) {
-        let tn = type_name::get<T>();
-        assert!(self.whitelist.contains(tn), ETypeNotWhitelisted);
-        *self.whitelist.borrow_mut<TypeName, bool>(tn) = false;
-    }
-    
-    public fun enable_type<T>(self: &mut EventVotes, _: &OrganizerCap) {
-        let tn = type_name::get<T>();
-        assert!(self.whitelist.contains(tn), ETypeNotWhitelisted);
-        *self.whitelist.borrow_mut<TypeName, bool>(tn) = true;
-    }
+public fun disable_type<T>(self: &mut EventVotes, _: &OrganizerCap) {
+    let tn = type_name::get<T>();
+    assert!(self.whitelist.contains(tn), ETypeNotWhitelisted);
+    *self.whitelist.borrow_mut<TypeName, bool>(tn) = false;
+}
 
-    public fun remove_type<T>(self: &mut EventVotes, _: &OrganizerCap) {
-        let tn = type_name::get<T>();
-        assert!(self.whitelist.contains(tn), ETypeNotWhitelisted);
-        self.whitelist.remove<TypeName, bool>(tn);
-    }
+public fun enable_type<T>(self: &mut EventVotes, _: &OrganizerCap) {
+    let tn = type_name::get<T>();
+    assert!(self.whitelist.contains(tn), ETypeNotWhitelisted);
+    *self.whitelist.borrow_mut<TypeName, bool>(tn) = true;
+}
 
-    public fun delete_event(self: EventVotes, _: &OrganizerCap) {
-        let EventVotes {id, name: _,  whitelist, votes, voter_used_id} = self;
-        whitelist.drop();
-        votes.drop();
-        voter_used_id.drop();
-        id.delete();
-    }
+public fun remove_type<T>(self: &mut EventVotes, _: &OrganizerCap) {
+    let tn = type_name::get<T>();
+    assert!(self.whitelist.contains(tn), ETypeNotWhitelisted);
+    self.whitelist.remove<TypeName, bool>(tn);
+}
 
-    // to be called in the same PTB as new_event
-    public fun share_event(self: EventVotes) {
-        transfer::share_object(self);
-    }
+public fun delete_event(self: EventVotes, _: &OrganizerCap) {
+    let EventVotes {id, name: _,  whitelist, votes, voter_used_id} = self;
+    whitelist.drop();
+    votes.drop();
+    voter_used_id.drop();
+    id.delete();
+}
 
-    // The only user function
+// to be called in the same PTB as new_event
+public fun share_event(self: EventVotes) {
+    transfer::share_object(self);
+}
 
-    public fun vote<T: key>(self: &mut EventVotes, nft: &T, submission: String, ctx: &mut TxContext) {
-        //check if submission exists
-        assert!(self.votes.contains(submission), EInvalidSubmission);
-        let tn = type_name::get<T>();
-        // check if valid type is presented
-        assert!(self.whitelist.contains(tn), ETypeNotWhitelisted);
-        // check that type is enabled
-        assert!(*self.whitelist.borrow<TypeName, bool>(tn), ETypeNotEnabled);
+// The only user function
 
-        let voter = ctx.sender();
-        // check if user has voted already with this ID
-        assert!(!self.voter_used_id.contains(object::id(nft)), EVoteAlreadyCast);
-        
+fun check_eligibility<T: key>(self: &EventVotes, nft: &T, submissions: vector<String>) {
+    //check if submissions exist
+    submissions.do!(|s| {
+        assert!(self.votes.contains(s), EInvalidSubmission);
+    });
+    let tn = type_name::get<T>();
+    // check if valid type is presented
+    assert!(self.whitelist.contains(tn), ETypeNotWhitelisted);
+    // check that type is enabled
+    assert!(*self.whitelist.borrow<TypeName, bool>(tn), ETypeNotEnabled);
+}
 
-        // add type to used ones
-        self.voter_used_id.add(object::id(nft), true);
+public fun vote<T: key>(self: &mut EventVotes, nft: &T, submissions: vector<String>, ctx: &mut TxContext) {
+    check_eligibility(self, nft, submissions);
+    // check if user has not voted already with this ID
+    assert!(!self.voter_used_id.contains(object::id(nft)), EVoteAlreadyCast);
 
+    // add type to used ones
+    self.voter_used_id.add(object::id(nft), true);
+
+    submissions.do!(|s| {
         // increase vote count
-        *self.votes.borrow_mut<String, u32>(submission) = *self.votes.borrow_mut<String, u32>(submission) + 1u32;
-    }
-
-
-    // getters
-
-    public fun votes(self: &mut EventVotes, submission: String): u32 {
-        *self.votes.borrow(submission)
-    }
-
-    // Test helpers
-    #[test_only]
-    public fun init_for_test(ctx: &mut TxContext) {
-        init(ctx);
-    }
-
+        *self.votes.borrow_mut<String, u32>(s) = *self.votes.borrow_mut<String, u32>(s) + 1u32;
+    });
+    let b = Ballot {
+        id: object::new(ctx),
+        votes: submissions
+    };
+    transfer::transfer(b, ctx.sender());
 }
+
+public fun revote<T: key>(self: &mut EventVotes, nft: &T, ballot: &mut Ballot, resubmissions: vector<String>) {
+    check_eligibility(self, nft, resubmissions);
+    // Check if user has voted already with this ID
+    assert!(self.voter_used_id.contains(object::id(nft)), EVoteNotCast);
+    
+    // decrease previous votes
+    ballot.votes.do!(|s| {
+        *self.votes.borrow_mut<String, u32>(s) = *self.votes.borrow_mut<String, u32>(s) - 1u32;
+    });
+
+    resubmissions.do!(|s| {
+        // increase vote count
+        *self.votes.borrow_mut<String, u32>(s) = *self.votes.borrow_mut<String, u32>(s) + 1u32;
+    });
+    ballot.votes = resubmissions;
+}
+
+
+// getters
+public fun votes(self: &mut EventVotes, submission: String): u32 {
+    *self.votes.borrow(submission)
+}
+
+// Test helpers
+#[test_only]
+public fun init_for_test(ctx: &mut TxContext) {
+    init(ctx);
+}
+

--- a/contract/sources/walrus_hackathon.move
+++ b/contract/sources/walrus_hackathon.move
@@ -1,13 +1,15 @@
 module contract::walrus_hackathon;
 
 use sui::vec_set::{Self,VecSet};
-use sui::random::{Self,Random,RandomGenerator};
+use sui::random::{Random};
 
 public struct ShortListed has key {
     id: UID,
     // If a team submitted 2 projects, they will need to provide different addresses
     // to be considered as 2 different teams
     projects: VecSet<address>,
+    team_orca: vector<address>,
+    team_polar_bear: vector<address>,
 }
 
 public struct TeamPolarBear has key {
@@ -30,8 +32,10 @@ fun init(ctx: &mut TxContext) {
     let short_listed = ShortListed {
         id: object::new(ctx),
         projects: vec_set::empty(),
+        team_orca: vector[],
+        team_polar_bear: vector[],
     };
-    transfer::share_object(short_listed);
+    transfer::transfer(short_listed, ctx.sender());
 }
 
 public fun add_projects(_: &OrganizerCap, sl: &mut ShortListed, new_projects: vector<address>) {
@@ -40,7 +44,15 @@ public fun add_projects(_: &OrganizerCap, sl: &mut ShortListed, new_projects: ve
     });
 }
 
-entry fun select_teams(random: &Random, _: &OrganizerCap, sl: &ShortListed, ctx: &mut TxContext) {
+public fun team_orca(self: &ShortListed): vector<address> {
+    self.team_orca
+}
+
+public fun team_polar_bear(self: &ShortListed): vector<address> {
+    self.team_polar_bear
+}
+
+entry fun select_teams(random: &Random, _: &OrganizerCap, sl: &mut ShortListed, ctx: &mut TxContext) {
     let mut rng = random.new_generator(ctx);
     let mut projects = sl.projects.into_keys();
     rng.shuffle(&mut projects);
@@ -54,15 +66,22 @@ entry fun select_teams(random: &Random, _: &OrganizerCap, sl: &ShortListed, ctx:
             let o = TeamOrca {
                 id: object::new(ctx)
             };
+            sl.team_orca.push_back(*projects.borrow(i));
             transfer::transfer(o, *projects.borrow(i));
         } else {
             let p = TeamPolarBear {
                 id: object::new(ctx)
             };
+            sl.team_polar_bear.push_back(*projects.borrow(i));
             transfer::transfer(p, *projects.borrow(i));
         };
 
         i = i + 1;
     }
+}
+
+#[test_only]
+public fun init_for_test(ctx: &mut TxContext) {
+    init(ctx);
 }
 

--- a/contract/tests/hackathon_tests.move
+++ b/contract/tests/hackathon_tests.move
@@ -1,0 +1,98 @@
+#[test_only]
+module contract::hackathon_tests {
+    use sui::test_scenario::{Self as ts, Scenario};
+    use sui::random::{Self,Random};
+
+    use contract::walrus_hackathon::{
+        Self,
+        OrganizerCap,
+        TeamPolarBear,
+        TeamOrca,
+        ShortListed,
+        add_projects,
+        select_teams,
+    };
+
+    const ORGANIZER: address = @0xAAA;
+    const Voter1: address = @0x111;
+    const Voter2: address = @0x222;
+    const Voter3: address = @0x333;
+    const Voter4: address = @0x444;
+    const Voter5: address = @0x555;
+
+
+    #[test]
+    public fun initialize(): Scenario {
+        let mut scenario = ts::begin(ORGANIZER);
+
+        let projects = vector[
+            Voter1,
+            Voter2,
+            Voter3,
+            Voter4,
+            Voter5,
+        ];
+
+        walrus_hackathon::init_for_test(scenario.ctx());
+
+        ts::next_tx(&mut scenario, ORGANIZER);
+        {
+            let cap = ts::take_from_sender<OrganizerCap>(&scenario);
+            let mut shortlisted = ts::take_from_sender<ShortListed>(&scenario);
+            add_projects(&cap, &mut shortlisted, projects);
+            scenario.return_to_sender<ShortListed>(shortlisted);
+            scenario.return_to_sender<OrganizerCap>(cap);
+        };
+
+        scenario
+    }
+
+    #[test]
+    public fun test_select_teams() {
+        let mut scenario = initialize();
+        ts::next_tx(&mut scenario, @0x0);
+        {
+            random::create_for_testing(scenario.ctx());
+        };
+
+        ts::next_tx(&mut scenario, @0x0);
+        let mut random_state: Random = scenario.take_shared();
+        {
+            random_state.update_randomness_state_for_testing(
+                0,
+                x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
+                scenario.ctx(),
+            );
+        };
+
+        ts::next_tx(&mut scenario, ORGANIZER);
+        {
+            let cap = scenario.take_from_sender<OrganizerCap>();
+            let mut shortlisted = ts::take_from_sender<ShortListed>(&scenario);
+
+            select_teams(&random_state, &cap, &mut shortlisted, scenario.ctx());
+
+            ts::return_shared<Random>(random_state);
+            scenario.return_to_sender<OrganizerCap>(cap);
+            scenario.return_to_sender<ShortListed>(shortlisted);
+        };
+
+        ts::next_tx(&mut scenario, ORGANIZER);
+        {
+            let shortlisted = ts::take_from_sender<ShortListed>(&scenario);
+            shortlisted.team_polar_bear().do!(|polar_addr| {
+                let polar_bear = scenario.take_from_address<TeamPolarBear>(polar_addr);
+                ts::return_to_address(polar_addr, polar_bear);
+            });
+            shortlisted.team_orca().do!(|orca_addr| {
+                let orca = scenario.take_from_address<TeamOrca>(orca_addr);
+                ts::return_to_address(orca_addr, orca);
+            });
+
+            scenario.return_to_sender(shortlisted);
+
+        };
+
+        scenario.end();
+    }
+}

--- a/contract/tests/voting_tests.move
+++ b/contract/tests/voting_tests.move
@@ -1,5 +1,6 @@
 #[test_only]
 module contract::voting_tests {
+    use std::debug;
     use sui::test_scenario::{Self as ts, Scenario};
 
     use std::string::{Self, String};
@@ -7,6 +8,7 @@ module contract::voting_tests {
     use contract::voting::{
         Self,
         OrganizerCap,
+        Ballot,
         EventVotes,
         ETypeNotEnabled,
         ETypeNotWhitelisted,
@@ -48,6 +50,7 @@ module contract::voting_tests {
             string::utf8(b"Sub1"),
             string::utf8(b"Sub2"),
             string::utf8(b"Sub3"),
+            string::utf8(b"Sub4"),
         ];
 
         voting::init_for_test(scenario.ctx());
@@ -56,8 +59,8 @@ module contract::voting_tests {
         {
             let cap = ts::take_from_sender<OrganizerCap>(&scenario);
             let mut event = voting::new_event(&cap, string::utf8(b"Hackahon"), submissions, scenario.ctx());
-            event.add_eligble_type<Type1>(&cap);
-            event.add_eligble_type<Type2>(&cap);
+            event.add_eligible_type<Type1>(&cap);
+            event.add_eligible_type<Type2>(&cap);
 
             voting::share_event(event);
             ts::return_to_sender<OrganizerCap>(&scenario, cap);
@@ -158,7 +161,7 @@ module contract::voting_tests {
             let nft_type1 = scenario.take_from_sender<Type1>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type1>(&nft_type1, string::utf8(b"Sub1"), scenario.ctx());
+            event.vote<Type1>(&nft_type1, vector[string::utf8(b"Sub1")], scenario.ctx());
 
             scenario.return_to_sender(nft_type1);
             ts::return_shared(event);
@@ -170,11 +173,56 @@ module contract::voting_tests {
             let nft_type1 = scenario.take_from_sender<Type1>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type1>(&nft_type1, string::utf8(b"Sub3"), scenario.ctx());
+            event.vote<Type1>(&nft_type1, vector[string::utf8(b"Sub3")], scenario.ctx());
 
             scenario.return_to_sender(nft_type1);
             ts::return_shared(event);
 
+        };
+
+        scenario.end();
+    }
+
+    #[test]
+    public fun test_revote() {
+        let mut scenario = initialize();
+        let sub1 = string::utf8(b"Sub1");
+        let sub2 = string::utf8(b"Sub2");
+        let sub3 = string::utf8(b"Sub3");
+        let sub4 = string::utf8(b"Sub4");
+
+        ts::next_tx(&mut scenario, VOTER1);
+        {
+            let nft_type1 = scenario.take_from_sender<Type1>();
+            let mut event = scenario.take_shared<EventVotes>();
+
+            event.vote<Type1>(&nft_type1, vector[sub1, sub2], scenario.ctx());
+
+            scenario.return_to_sender(nft_type1);
+            ts::return_shared(event);
+
+        };
+
+        ts::next_tx(&mut scenario, VOTER1);
+        {
+            let nft_type1 = scenario.take_from_sender<Type1>();
+            let mut ballot = scenario.take_from_sender<Ballot>();
+            let mut event = scenario.take_shared<EventVotes>();
+
+            assert!(&event.votes(sub1) == 1u32);
+            assert!(&event.votes(sub2) == 1u32);
+            assert!(&event.votes(sub3) == 0u32);
+            assert!(&event.votes(sub4) == 0u32);
+
+            event.revote<Type1>(&nft_type1, &mut ballot, vector[sub3, sub4]);
+
+            assert!(&event.votes(sub1) == 0u32);
+            assert!(&event.votes(sub2) == 0u32);
+            assert!(&event.votes(sub3) == 1u32);
+            assert!(&event.votes(sub4) == 1u32);
+            scenario.return_to_sender(nft_type1);
+            scenario.return_to_sender(ballot);
+            ts::return_shared(event);
         };
 
         scenario.end();
@@ -189,7 +237,7 @@ module contract::voting_tests {
             let nft_type1 = scenario.take_from_sender<Type1>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type1>(&nft_type1, string::utf8(b"Sub1"), scenario.ctx());
+            event.vote<Type1>(&nft_type1, vector[string::utf8(b"Sub1")], scenario.ctx());
 
             ts::return_to_sender(&scenario, nft_type1);
             ts::return_shared(event);
@@ -201,7 +249,7 @@ module contract::voting_tests {
             let nft_type2 = scenario.take_from_sender<Type2>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type2>(&nft_type2, string::utf8(b"Sub3"), scenario.ctx());
+            event.vote<Type2>(&nft_type2, vector[string::utf8(b"Sub3")], scenario.ctx());
 
             ts::return_to_sender(&scenario, nft_type2);
             ts::return_shared(event);
@@ -213,7 +261,7 @@ module contract::voting_tests {
             let nft_type1 = scenario.take_from_sender<Type1>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type1>(&nft_type1, string::utf8(b"Sub3"), scenario.ctx());
+            event.vote<Type1>(&nft_type1, vector[string::utf8(b"Sub3")], scenario.ctx());
 
             ts::return_to_sender(&scenario, nft_type1);
             ts::return_shared(event);
@@ -243,7 +291,7 @@ module contract::voting_tests {
             let nft_type1 = scenario.take_from_sender<Type1>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type1>(&nft_type1, string::utf8(b"Sub1"), scenario.ctx());
+            event.vote<Type1>(&nft_type1, vector[string::utf8(b"Sub1")], scenario.ctx());
 
             ts::return_to_sender(&scenario, nft_type1);
             ts::return_shared(event); 
@@ -261,7 +309,7 @@ module contract::voting_tests {
             let nft_type1 = scenario.take_from_sender<Type1>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type1>(&nft_type1, string::utf8(b"Sub1"), scenario.ctx());
+            event.vote<Type1>(&nft_type1, vector[string::utf8(b"Sub1")], scenario.ctx());
 
             ts::return_to_sender(&scenario, nft_type1);
             ts::return_shared(event); 
@@ -280,7 +328,7 @@ module contract::voting_tests {
             let nft_type1 = scenario.take_from_sender<Type1>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type1>(&nft_type1, string::utf8(b"Sub1"), scenario.ctx());
+            event.vote<Type1>(&nft_type1, vector[string::utf8(b"Sub1")], scenario.ctx());
 
             ts::return_to_sender(&scenario, nft_type1);
             ts::return_shared(event); 
@@ -291,7 +339,7 @@ module contract::voting_tests {
             let nft_type1 = scenario.take_from_sender<Type1>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type1>(&nft_type1, string::utf8(b"Sub1"), scenario.ctx());
+            event.vote<Type1>(&nft_type1, vector[string::utf8(b"Sub1")], scenario.ctx());
 
             ts::return_to_sender(&scenario, nft_type1);
             ts::return_shared(event); 
@@ -309,7 +357,7 @@ module contract::voting_tests {
             let nft_type1 = scenario.take_from_sender<Type1>();
             let mut event = scenario.take_shared<EventVotes>();
 
-            event.vote<Type1>(&nft_type1, string::utf8(b"Eis D. Zaster"), scenario.ctx());
+            event.vote<Type1>(&nft_type1, vector[string::utf8(b"Eis D. Zaster")], scenario.ctx());
 
             ts::return_to_sender(&scenario, nft_type1);
             ts::return_shared(event); 

--- a/contract/tests/voting_tests.move
+++ b/contract/tests/voting_tests.move
@@ -1,6 +1,5 @@
 #[test_only]
 module contract::voting_tests {
-    use std::debug;
     use sui::test_scenario::{Self as ts, Scenario};
 
     use std::string::{Self, String};
@@ -141,7 +140,7 @@ module contract::voting_tests {
         scenario.next_tx(ORGANIZER);
         {
             let cap = ts::take_from_sender<OrganizerCap>(&scenario);
-            let mut event = scenario.take_shared<EventVotes>();
+            let event = scenario.take_shared<EventVotes>();
 
             event.delete_event(&cap);
 


### PR DESCRIPTION
What I changed:
- Added support to vote for multiple projects at the same time
- Allowed revotes
- Updated tests to support revotes and multi votes
- Added contract for hackathon that splits project submissions into 2 teams

The idea for the hackathon voting is to:
1. collect Sui address from each shortlisted team (if a team submits more than 1 projects, they would need to provide more than one address)
2. Shuffle the order on-chain and split into 2 camps and issue 2 different tokens for each camp
3. Load the 2 vectors to the `voting` contract and create 2 separate `EventVotes` that whitelists different tokens. Each camp can only vote for the other camp to discourage tactical voting. 